### PR TITLE
Corrected type defs to match docs

### DIFF
--- a/types/discord_game.d.ts
+++ b/types/discord_game.d.ts
@@ -8,7 +8,7 @@
 export as namespace Discord;
 
 export const version: number;
-export function create(appId: string);
+export function create(appId: string, isRequireDiscord: boolean): boolean;
 export function runCallback(): boolean;
 
 /**


### PR DESCRIPTION
Fixes a TypeScript definition mismatch where a missing `is_Required` argument in `Discord.create()` could lead to an assertion runtime error similar to #29.